### PR TITLE
ChatIM: capture per-frame chat for copy window and add Copy Source setting

### DIFF
--- a/Modules/ChatIM.lua
+++ b/Modules/ChatIM.lua
@@ -13,6 +13,7 @@ local lastWhisperSoundAt = 0
 local copyFrame, copyBox, copyScroll
 local copyButton
 local copyDrop, copyFollowToggle
+local addMessageHooksInstalled = false
 
 -- Per-frame rolling history
 local historyByFrameId = {} -- [id] = { lines = {}, max = number }
@@ -126,6 +127,25 @@ local function Push(frameId, line, max)
   end
 end
 
+local function InstallAddMessageHooks()
+  if addMessageHooksInstalled then return end
+  addMessageHooksInstalled = true
+
+  local n = NUM_CHAT_WINDOWS or 10
+  for i = 1, n do
+    local cf = _G["ChatFrame" .. i]
+    if cf and cf.AddMessage then
+      hooksecurefunc(cf, "AddMessage", function(self, text)
+        local db = GetDB()
+        if not (ETBC.db.profile.general.enabled and db.enabled) then return end
+
+        local maxKeep = math.max(2000, tonumber(db.copyLines) or 200)
+        Push(i, StripCodes(text), maxKeep)
+      end)
+    end
+  end
+end
+
 local function FindFrameIdForFilterSelf(self)
   -- In many builds, filter "self" is ChatFrameX (or its underlying frame)
   if type(self) ~= "table" then return 1 end
@@ -215,16 +235,6 @@ end
 -- IMPORTANT: Correct signature is (self, event, msg, author, ...)
 local function Filter(self, event, msg, author, ...)
   local db = GetDB()
-
-  if ETBC.db.profile.general.enabled and db.enabled then
-    local frameId = FindFrameIdForFilterSelf(self)
-    local maxKeep = math.max(2000, tonumber(db.copyLines) or 200)
-
-    local prefix = EventPrefix(event)
-    local a = (type(author) == "string" and author ~= "" and author) or "?"
-    local plain = prefix .. a .. ": " .. StripCodes(EscapePercents(msg))
-    Push(frameId, plain, maxKeep)
-  end
 
   if not (ETBC.db.profile.general.enabled and db.enabled) then
     return false, msg, author, ...
@@ -560,6 +570,7 @@ local function Apply()
 
   if enabled then
     RegisterFilters()
+    InstallAddMessageHooks()
     HookURLClick()
     RegisterCommands()
 

--- a/Settings/Settings_ChatIM.lua
+++ b/Settings/Settings_ChatIM.lua
@@ -206,10 +206,30 @@ ETBC.SettingsRegistry:RegisterGroup("chatim", {
             set = function(_, v) db.copyButtonAlpha = v; ETBC.ApplyBus:Notify("chatim") end,
             disabled = function() return not (db.enabled and db.copyButton) end,
           },
+          copyTarget = {
+            type = "select",
+            name = "Copy Source",
+            order = 5,
+            values = function()
+              local values = { follow = "Follow current tab" }
+              local n = NUM_CHAT_WINDOWS or 10
+              for i = 1, n do
+                local title = GetChatWindowInfo and select(1, GetChatWindowInfo(i))
+                if not title or title == "" then
+                  title = "ChatFrame" .. i
+                end
+                values[tostring(i)] = title
+              end
+              return values
+            end,
+            get = function() return db.copyTarget end,
+            set = function(_, v) db.copyTarget = v; ETBC.ApplyBus:Notify("chatim") end,
+            disabled = function() return not db.enabled end,
+          },
           hint = {
             type = "description",
             name = "Command: |cff33ff99/etbccopy|r",
-            order = 5,
+            order = 6,
           },
         },
       },


### PR DESCRIPTION
### Motivation
- The chat copy window was capturing mixed channel traffic (including global spam) because history was recorded from the message filter path which does not reliably map messages to the visible chat frame.
- Expose a user-configurable source so the copy UI can target either the currently-followed tab or a specific chat frame.

### Description
- Added `copyTarget` select setting to `Settings/Settings_ChatIM.lua` to allow choosing `Follow current tab` or any specific `ChatFrameN` in the settings UI and wired it to `db.copyTarget` with `ETBC.ApplyBus:Notify("chatim")` on change.
- Implemented `InstallAddMessageHooks()` in `Modules/ChatIM.lua` which one-time hooks `ChatFrame1..N:AddMessage` using `hooksecurefunc` and pushes stripped text into per-frame history buckets so history matches what each frame actually displays.
- Removed the previous history push from the `Filter` path so per-frame history is no longer polluted by events that aren’t actually shown in the target chat frame, while retaining existing transformations (timestamps, linkifying, channel shortening) in the filter.
- Called `InstallAddMessageHooks()` during `Apply()` when the module is enabled so hooks are installed when ChatIM is active.

### Testing
- Ran a `git diff` to review the changes to `Modules/ChatIM.lua` and `Settings/Settings_ChatIM.lua`, which showed the new hooks and new setting (success).
- Attempted to run `luac -p` to validate Lua syntax, but `luac` is not available in this environment (tooling limitation), so syntax check could not be completed here (failure due to missing tool).
- Committed the changes with `git commit` to record the update (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698feb43da64832e978e6c46894137e7)