### PR TITLE
Fix flyout blank icons, persist flyout position, and tracking icon target (invisible toggle)

### DIFF
--- a/Modules/Minimap.lua
+++ b/Modules/Minimap.lua
@@ -147,10 +147,10 @@ local function GetDB()
   if f.pos.x == nil then f.pos.x = 0 end
   if f.pos.y == nil then f.pos.y = -8 end
 
-  if f.toggle.point == nil then f.toggle.point = "RIGHT" end
-  if f.toggle.relPoint == nil then f.toggle.relPoint = "RIGHT" end
-  if f.toggle.x == nil then f.toggle.x = 10 end
-  if f.toggle.y == nil then f.toggle.y = 0 end
+  if f.toggle.point == nil then f.toggle.point = "BOTTOM" end
+  if f.toggle.relPoint == nil then f.toggle.relPoint = "BOTTOM" end
+  if f.toggle.x == nil then f.toggle.x = 0 end
+  if f.toggle.y == nil then f.toggle.y = -14 end
 
   -- keep collector in sync for legacy readers
   c.enabled, c.locked, c.startOpen = f.enabled, f.locked, f.startOpen
@@ -279,6 +279,12 @@ local function ApplyDefaultArt(db)
 
   local moon = _G.GameTimeFrame
   if moon and moon.SetShown then moon:SetShown(false) end
+
+  local clusterTop = (_G.MinimapCluster and _G.MinimapCluster.BorderTop) or _G.MinimapClusterBorderTop
+  if clusterTop and clusterTop.SetShown then clusterTop:SetShown(false) end
+
+  local toggleBtn = _G.MiniMapToggleButton
+  if toggleBtn and toggleBtn.SetShown then toggleBtn:SetShown(false) end
 end
 
 -- ------------------------------------------------------------
@@ -504,7 +510,19 @@ local function AnchorBlizz(btn, point, relPoint, x, y, size)
   NormalizeButtonHitRect(btn)
   if btn == FindTracking() then
     local ticon = _G.MiniMapTrackingButtonIcon or _G.MiniMapTrackingIcon or _G.MinimapTrackingIcon
+    local tbg = _G.MiniMapTrackingBackground or _G.MinimapTrackingBackground
     local tborder = _G.MiniMapTrackingButtonBorder or _G.MinimapTrackingButtonBorder
+
+    if tbg then
+      if tbg.SetParent then tbg:SetParent(btn) end
+      if tbg.ClearAllPoints then
+        tbg:ClearAllPoints()
+        tbg:SetAllPoints(btn)
+      end
+      if tbg.SetDrawLayer then tbg:SetDrawLayer("BACKGROUND", 0) end
+      if tbg.SetAlpha then tbg:SetAlpha(1) end
+      if tbg.Show then tbg:Show() end
+    end
 
     if ticon then
       if ticon.SetParent then ticon:SetParent(btn) end
@@ -529,6 +547,7 @@ local function AnchorBlizz(btn, point, relPoint, x, y, size)
         tborder:SetAllPoints(btn)
       end
       if tborder.SetDrawLayer then tborder:SetDrawLayer("OVERLAY", 2) end
+      if tborder.SetAlpha then tborder:SetAlpha(1) end
       if tborder.Show then tborder:Show() end
     end
   end

--- a/Settings/Settings_Minimap.lua
+++ b/Settings/Settings_Minimap.lua
@@ -87,10 +87,10 @@ local function EnsureDB()
   if db.flyout.pos.y == nil then db.flyout.pos.y = -8 end
 
   db.flyout.toggle = db.flyout.toggle or {}
-  if db.flyout.toggle.point == nil then db.flyout.toggle.point = "RIGHT" end
-  if db.flyout.toggle.relPoint == nil then db.flyout.toggle.relPoint = "RIGHT" end
-  if db.flyout.toggle.x == nil then db.flyout.toggle.x = 10 end
-  if db.flyout.toggle.y == nil then db.flyout.toggle.y = 0 end
+  if db.flyout.toggle.point == nil then db.flyout.toggle.point = "BOTTOM" end
+  if db.flyout.toggle.relPoint == nil then db.flyout.toggle.relPoint = "BOTTOM" end
+  if db.flyout.toggle.x == nil then db.flyout.toggle.x = 0 end
+  if db.flyout.toggle.y == nil then db.flyout.toggle.y = -14 end
 
   return db
 end
@@ -291,7 +291,7 @@ ETBC.SettingsRegistry:RegisterGroup("minimap", {
         disabled=function() return not (db.enabled and db.flyout.enabled) end,
         func=function()
           db.flyout.pos.point, db.flyout.pos.relPoint, db.flyout.pos.x, db.flyout.pos.y = "TOPRIGHT", "BOTTOMRIGHT", 0, -8
-          db.flyout.toggle.point, db.flyout.toggle.relPoint, db.flyout.toggle.x, db.flyout.toggle.y = "RIGHT", "RIGHT", 10, 0
+          db.flyout.toggle.point, db.flyout.toggle.relPoint, db.flyout.toggle.x, db.flyout.toggle.y = "BOTTOM", "BOTTOM", 0, -14
           Notify()
         end,
       },


### PR DESCRIPTION
### Motivation
- Flyout proxy icons were blank because some source buttons clear their textures when hidden, and the flyout toggle was visually intrusive; the flyout position also reset after reopening.
- The tracking dropdown button icon was not always being picked up by the previous icon lookup logic.
- Settings/DB access and apply wiring required harmonization to support the above flyout behavior changes.

### Description
- Cache and render visuals: added `ExtractVisualData()` and a `fly.visuals` cache, capture icon texture/texcoords before hiding source buttons, and use cached visuals in `UpdateProxyVisual()` so proxies remain visible even if sources clear textures on hide. 
- Invisible-but-clickable toggle: removed backdrop/label and set the toggle alpha to `0` while keeping mouse enabled so the toggle remains functional but not visible. 
- Persistent, minimap-relative flyout position: changed `OnDragStop` to store center offsets relative to the Minimap (`CENTER` → `CENTER` with x/y offsets) so the flyout reopens at the user-placed location. 
- Tracking icon fallback and anchor fixes: expanded preferred icon lookup and anchor logic to check `_G.MiniMapTrackingButtonIcon` (and keep previous fallbacks) and apply `GetTrackingTexture()` when available so the tracking button displays correctly. 
- Settings/API and apply flow: refactored DB default filling (new `GetDB`/`EnsureDB` behavior), added `GetLDBIconDataForButton()` helper, ensured `Apply`/`RefreshFlyout` handle disabled states and start-open logic, and guarded calls with `SafeCall` where appropriate.

### Testing
- Ran `rg` and `git diff -- Modules/Minimap.lua` to inspect symbol changes and confirm code deltas (succeeded). 
- Committed changes locally (`git commit`) and verified workspace status with `git status --short` (succeeded). 
- Performed static checks by printing the modified file fragments to validate inserted helpers and replaced blocks (succeeded). 
- Runtime/visual verification (in-game) could not be executed here because a Lua WoW runtime is not available in this environment; manual validation in-game is still recommended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fca2f4b5c832ead55efc3cc4c3f18)